### PR TITLE
Update minimum "extend" version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "data-uri-to-buffer": "1",
     "ftp": "~0.3.10",
     "debug": "2",
-    "extend": "3",
+    "extend": "~3.0.2",
     "file-uri-to-path": "1",
     "readable-stream": "2"
   }


### PR DESCRIPTION
extend 3.0.1 has a known vulnerability, fixed in 3.0.2. Due to the way that npm sometimes dedupes trees, the minimum version here appears to occasionally pull in 3.0.1. Raise the minimum so that consumers don't accidentally pull in a vulnerable dependency.