### PR TITLE
Make `opts` optional for Promise interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ function getUri(
 	opts: getUri.GetUriOptions,
 	fn: getUri.GetUriCallback
 ): void;
-function getUri(uri: string, opts: getUri.GetUriOptions): Promise<Readable>;
+function getUri(uri: string, opts?: getUri.GetUriOptions): Promise<Readable>;
 function getUri(
 	uri: string,
 	opts?: getUri.GetUriOptions | getUri.GetUriCallback,


### PR DESCRIPTION
Fixes #22.